### PR TITLE
Rely on Google ad framework directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ event buffering by setting the key `enableEventBuffering` to `true`.
 
 Since the 1st of August of 2014, apps in the Google Play Store must use the [Google Advertising ID][google_ad_id] to uniquely identify the devices. To allow the adjust SDK to use the Google Advertising ID, you must integrate the [Google Play Services][google_play_services].
 
-You can integrate Google Play Services into a Cordova project by installing a corresponding [plugin][google_play_services_plugin].
+Assuming you have the appropriate repositories available, this plugin will install the necessary Google services frameworks for that.
 
 If you are using Proguard, add these lines to your Proguard file:
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,8 @@
             target-dir="src/com/adjust" />
         <source-file src="src/android/com/adjust/sdk/AdjustCordova.java"
             target-dir="src/com/adjust/sdk" />
+        <framework src="com.google.android.gms:play-services-identity:+" />
+        <framework src="com.google.android.gms:play-services-ads:+" />
     </platform>
     <!-- ios -->
     <platform name="ios">
@@ -47,7 +49,7 @@
 
         <header-file src="src/ios/AdjustCordova.h" />
         <source-file src="src/ios/AdjustCordova.m" /> 
-        
+
         <header-file src="src/ios/Adjust/Adjust/Adjust.h" />
         <source-file src="src/ios/Adjust/Adjust/Adjust.m" /> 
         <header-file src="src/ios/Adjust/Adjust/AIActivityHandler.h" />


### PR DESCRIPTION
The recommended Google Play Services [1] plugin says that it's
deprecated and suggests you include framework tags instead of relying on
it. Modified the plugin.xml to do that.

[1] https://github.com/MobileChromeApps/google-play-services --- see
commit 3566ed0a81bc162d398f726648e2a06edc0aed49