### PR TITLE
Use uppercase letters in `plugin.xml` to match path names on file system

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@
             </feature>
         </config-file>
 
-        <source-file src="src/android/adjust-android.jar" target-dir="libs" />
+        <source-file src="src/Android/adjust-android.jar" target-dir="libs" />
 
         <framework src="com.google.android.gms:play-services-ads:+" />
     </platform>
@@ -63,10 +63,10 @@
           </feature>
         </config-file>
 
-        <header-file src="src/ios/AdjustCordova.h" />
-        <source-file src="src/ios/AdjustCordova.m" /> 
+        <header-file src="src/iOS/AdjustCordova.h" />
+        <source-file src="src/iOS/AdjustCordova.m" />
 
-        <framework src="src/ios/Adjust.framework" custom="true" />
+        <framework src="src/iOS/Adjust.framework" custom="true" />
         <framework src="AdSupport.framework" weak="true" />
         <framework src="iAd.framework" weak="true" />
     </platform>


### PR DESCRIPTION
The submitted pull request changes the paths in `plugin.xml` so that they match with the real paths in the file system.

This is necessary because `src/android/adjust-android.jar` is actually in `src/Android/adjust-android.jar`. Casing in filenames doesn't matter under OS X, but most of the file systems (ext4) under Linux are case sensitive.

(Error messages when running `cordova platform install <local-path-to-plugin>`:

```
Updated the hooks directory to have execute permissions
Installing "com.adjust.sdk" for android
Error during processing of action! Attempting to revert...
Failed to install 'com.adjust.sdk':Error: Uh oh!
"/home/[...]/plugins/com.adjust.sdk/src/android/adjust-android.jar" not found!
    at Object.module.exports.common.copyFile (/home/malte/.nvm/versions/v0.12.1/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/common.js:38:40)
    at Object.module.exports.common.copyNewFile (/home/malte/.nvm/versions/v0.12.1/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/common.js:69:16)
    at module.exports.source-file.install (/home/malte/.nvm/versions/v0.12.1/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/android.js:78:20)
  [...]
```
)
