### PR TITLE
Set a framework version instead of latest

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@
         <source-file src="src/Android/AdjustCordova.java" target-dir="src/com/adjust/sdk" />
         <source-file src="src/Android/adjust-android.jar" target-dir="libs" />
 
-        <framework src="com.google.android.gms:play-services-analytics:+" />
+        <framework src="com.google.android.gms:play-services-analytics:8.3.0" />
     </platform>
 
     <!-- iOS -->


### PR DESCRIPTION
Ludei, creator of Cocoon says this about "`<framework src="com.google.android.gms:play-services-analytics:+" />`" : "That is not very recomendable because if you use just the latest version available in the system and at some point you have installed a newer version than the plugin was developed with, things can start not to compile.

You can solve the issue forking the repos and setting the framework to 8.3.0 in the plugin.xml:

<framework src="com.google.android.gms:play-services-analytics:8.3.0" />

Why did this not happen before? Probably because now in the compilation machines a newer version of GMS is available, that's why is not recommendable to mix different versions of GMS, it's a bad practice but it seems people keep on doing it. The good thing to do it to offer the developers fixed this party library versions of the plugins that we have forked to work properly with Cocoon."

Tested and confirmed to be working with Cocoon.