### PR TITLE
use cocoapods and gradle to fetch the adjust framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,8 +59,7 @@
 
         <source-file src="src/android/AdjustCordova.java" target-dir="src/com/adjust/sdk" />
         <source-file src="src/android/AdjustCordovaUtils.java" target-dir="src/com/adjust/sdk" />
-        <lib-file src="src/android/adjust-android.jar" target-dir="libs" />
-
+        <framework src="com.adjust.sdk:adjust-android:4.24.0" />
         <framework src="com.google.android.gms:play-services-analytics:+" />
         <framework src="com.android.installreferrer:installreferrer:1.0" />
     </platform>
@@ -79,7 +78,14 @@
         <header-file src="src/ios/AdjustCordovaDelegate.h" />
         <source-file src="src/ios/AdjustCordovaDelegate.m" />
 
-        <framework src="src/ios/AdjustSdk.framework" custom="true" />
+        <podspec>
+            <config>
+                <source url="https://cdn.cocoapods.org/"/>
+            </config>
+            <pods use-frameworks="true">
+                <pod name="Adjust" spec="4.24.0"/>
+            </pods>
+        </podspec>
         <framework src="AdSupport.framework" weak="true" />
         <framework src="iAd.framework" weak="true" />
         <framework src="CoreTelephony.framework" weak="true" />


### PR DESCRIPTION
In order to build with Cocoapods for iOS and fetch the gradle framework instead of hosting a jar file for Android,